### PR TITLE
Vertical text shouldn't defy gravity

### DIFF
--- a/lib/assets/discord/user/image.tsx
+++ b/lib/assets/discord/user/image.tsx
@@ -419,9 +419,7 @@ export const DiscordImage = async (
                       ? lanyard.data.spotify.album_art_url
                       : lanyard.data.activities[0]?.assets?.large_image
                       ? `https://cdn.discordapp.com/app-assets/${BigInt(
-                          lanyard.data.activities[0].application_id
-                            ? lanyard.data.activities[0].application_id
-                            : 0
+                          lanyard.data.activities[0].application_id ?? 0
                         ).toString()}/${
                           lanyard.data.activities[0].assets.large_image
                         }.png`
@@ -450,7 +448,7 @@ export const DiscordImage = async (
                               ? "https://www.freepnglogos.com/uploads/spotify-logo-png/file-spotify-logo-png-4.png"
                               : lanyard.data.activities[0]?.assets?.small_image
                               ? `https://cdn.discordapp.com/app-assets/${BigInt(
-                                  lanyard.data.activities[0].application_id ? lanyard.data.activities[0].application_id : 0
+                                  lanyard.data.activities[0].application_id ?? 0
                                 ).toString()}/${
                                   lanyard.data.activities[0].assets.small_image
                                 }.png`
@@ -472,7 +470,7 @@ export const DiscordImage = async (
               ? lanyard.data.spotify.album_art_url
               : lanyard.data.activities[1]?.assets?.large_image
               ? `https://cdn.discordapp.com/app-assets/${BigInt(
-                  lanyard.data.activities[1].application_id ? lanyard.data.activities[1].application_id : 0
+                  lanyard.data.activities[1].application_id ?? 0
                 ).toString()}/${
                   lanyard.data.activities[1].assets.large_image
                 }.png`
@@ -501,7 +499,7 @@ export const DiscordImage = async (
                               ? "https://www.freepnglogos.com/uploads/spotify-logo-png/file-spotify-logo-png-4.png"
                               : lanyard.data.activities[1]?.assets?.small_image
                               ? `https://cdn.discordapp.com/app-assets/${BigInt(
-                                  lanyard.data.activities[1].application_id ? lanyard.data.activities[1].application_id : 0
+                                  lanyard.data.activities[1].application_id ?? 0
                                 ).toString()}/${
                                   lanyard.data.activities[1].assets.small_image
                                 }.png`


### PR DESCRIPTION
Fix the vertical text from being in the centre (e.g.):

![before](https://woah.wtf/pUAn6h:K8YwNj)

to:
![after](https://presence.vercel.app/api/twitter/tweet/1394507872017403904?type=png&theme=dark&rounded=true)